### PR TITLE
Consider renaming `final`

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,12 +27,12 @@
       len : end >> 0;
 
     // Step 11.
-    var final = relativeEnd < 0 ?
+    var last = relativeEnd < 0 ?
       Math.max(len + relativeEnd, 0) :
       Math.min(relativeEnd, len);
 
     // Step 12.
-    while (k < final) {
+    while (k < last) {
       O[k] = value;
       k++;
     }


### PR DESCRIPTION
Although completely fine in ES5, `final` is a future reserved word in [ES3](http://www.ecma-international.org/publications/files/ECMA-ST-ARCH/ECMA-262,%203rd%20edition,%20December%201999.pdf) (section 7.5.3), so parsing fails on some old interpreters.

Consider changing the variable name to something else.